### PR TITLE
Git ignore *.o and binary kmer-db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,7 @@
 *.sqlite
 *.json
 *.suo
+*.o
 /src/kmer_db.vcxproj.user
 /src/.vs
+/kmer-db


### PR DESCRIPTION
This patch adds the build artefacts on Linux (the `*.o` files and the `kmer-db` binary) to `.gitignore`.